### PR TITLE
deprecate google drive in favor of huggingface

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For business inquiries, please submit this form: [NVIDIA Research Licensing](htt
 
 -------
 ## Latest Updates
+- [09/19/2024] **v1.0.1**: Datasets hosted only on Hugging Face (Google Drive deprecated)
 - [07/09/2024] **v1.0.0**: Full code release, including data generation code
 - [04/04/2024] **v0.1.1**: Dataset license changed to [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/), which is less restrictive (see [License](#license))
 - [09/28/2023] **v0.1.0**: Initial code and paper release

--- a/docs/datasets/mimicgen_corl_2023.md
+++ b/docs/datasets/mimicgen_corl_2023.md
@@ -63,15 +63,9 @@ python download_datasets.py --dataset_type core --tasks all --dry_run
 python download_datasets.py --dataset_type source --tasks all
 ```
 
-#### Method 2: Using Direct Download Links
+#### Method 2: Using Hugging Face
 
-You can download the datasets manually through Google Drive. The folders each correspond to the dataset types described in [Dataset Types](#dataset-types).
-
-**Google Drive folder with all datasets:** [link](https://drive.google.com/drive/folders/14e9kkHGfApuQ709LBEbXrXVI1Lp5Ax7p?usp=drive_link)
-
-#### Method 3: Using Hugging Face
-
-You can download the datasets through Hugging Face.
+You can download the datasets through Hugging Face by using direct download links from the HF dataset page, or by using their API.
 
 **Hugging Face dataset repository:** [link](https://huggingface.co/datasets/amandlek/mimicgen_datasets)
 

--- a/mimicgen/__init__.py
+++ b/mimicgen/__init__.py
@@ -2,7 +2,7 @@
 #
 # Licensed under the NVIDIA Source Code License [see LICENSE for details].
 
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 # try to import all environment interfaces here
 try:
@@ -37,11 +37,14 @@ except ImportError as e:
 # robosuite
 # {
 #   task:
-#       url: link
+#       url: path in Hugging Face repo
 #       horizon: value
 #   ...
 # }
 DATASET_REGISTRY = {}
+
+# Hugging Face repo ID
+HF_REPO_ID = "amandlek/mimicgen_datasets"
 
 
 def register_dataset_link(dataset_type, task, link, horizon):
@@ -72,18 +75,18 @@ def register_all_links():
 
     # info for each dataset (name, evaluation horizon, link)
     dataset_infos = [
-        ("hammer_cleanup", 500, "https://drive.google.com/file/d/15EENNeAjm0nhaA2DxszUfvKBbm7tMKP8/view?usp=drive_link"),
-        ("kitchen", 800, "https://drive.google.com/file/d/15OSYVQBKWjA_0Qb7vgSJxg0ePk5tPGHO/view?usp=drive_link"),
-        ("coffee", 400, "https://drive.google.com/file/d/15LLftHGAzKw-t--KmA4Q9esNxSef8lmI/view?usp=drive_link"),
-        ("coffee_preparation", 800, "https://drive.google.com/file/d/15KlgnIurTeHsUakHvWixVXtA7Bh7A6Gt/view?usp=drive_link"),
-        ("nut_assembly", 500, "https://drive.google.com/file/d/150oTa-yEHxSsOduiiai0CpQ1pfPY14PF/view?usp=drive_link"),
-        ("mug_cleanup", 500, "https://drive.google.com/file/d/15JHCOZabMN6XBHj_cXsS0QPPsJeQiPAN/view?usp=drive_link"),
-        ("pick_place", 1000, "https://drive.google.com/file/d/15U2_Qm9y8CQ3HF6c-HbVJMtyEdeEccZv/view?usp=drive_link"),
-        ("square", 400, "https://drive.google.com/file/d/15CCPUGukZqJmFoFRDYDadu7lIVot_2hC/view?usp=drive_link"),
-        ("stack", 400, "https://drive.google.com/file/d/1519sVqkLD6PlI2pir8yjCpyogX1PfjUP/view?usp=drive_link"),
-        ("stack_three", 400, "https://drive.google.com/file/d/151ur_DIhO2Nlp3ipnKuQlcVK_IkE2Ago/view?usp=drive_link"),
-        ("threading", 400, "https://drive.google.com/file/d/15CzLAf_tAjwWnAFIaWsiyoPNYb3m84IK/view?usp=drive_link"),
-        ("three_piece_assembly", 500, "https://drive.google.com/file/d/159aWGouuiKOsf8YblSR5Lkfq9d1aCVCV/view?usp=drive_link"),
+        ("hammer_cleanup", 500, "source/hammer_cleanup.hdf5"),
+        ("kitchen", 800, "source/kitchen.hdf5"),
+        ("coffee", 400, "source/coffee.hdf5"),
+        ("coffee_preparation", 800, "source/coffee_preparation.hdf5"),
+        ("nut_assembly", 500, "source/nut_assembly.hdf5"),
+        ("mug_cleanup", 500, "source/mug_cleanup.hdf5"),
+        ("pick_place", 1000, "source/pick_place.hdf5"),
+        ("square", 400, "source/square.hdf5"),
+        ("stack", 400, "source/stack.hdf5"),
+        ("stack_three", 400, "source/stack_three.hdf5"),
+        ("threading", 400, "source/threading.hdf5"),
+        ("three_piece_assembly", 500, "source/three_piece_assembly.hdf5"),
     ]
     for task, horizon, link in dataset_infos:
         register_dataset_link(
@@ -96,32 +99,32 @@ def register_all_links():
     ### core generated datasets ###
     dataset_type = "core"
     dataset_infos = [
-        ("hammer_cleanup_d0", 500, "https://drive.google.com/file/d/1uLQSFqTiRquUbe3NprHSCVhLyOqjjrVR/view?usp=drive_link"),
-        ("hammer_cleanup_d1", 500, "https://drive.google.com/file/d/1YL-cSs9dC3lsA3LxQVZ0w98ijTnSdbSH/view?usp=drive_link"),
-        ("kitchen_d0", 800, "https://drive.google.com/file/d/1RPu6xTx8SFL5k9XpYUoR8Y5eZsbhqojj/view?usp=drive_link"),
-        ("kitchen_d1", 800, "https://drive.google.com/file/d/12X7p60JpDkyD4Ia8gjn0qn6VNy7RFuLX/view?usp=drive_link"),
-        ("coffee_d0", 400, "https://drive.google.com/file/d/1-0gQILd2jkhiOqTuh_bpP8wnidHrZXr2/view?usp=drive_link"),
-        ("coffee_d1", 400, "https://drive.google.com/file/d/1rsOhOzlJnimXxGM9Oi7S9by1UpgSrdQK/view?usp=drive_link"),
-        ("coffee_d2", 400, "https://drive.google.com/file/d/11X2d6WsRq1rQZzxTD9Gd23562VQ0k7OW/view?usp=drive_link"),
-        ("coffee_preparation_d0", 800, "https://drive.google.com/file/d/1OsEvnTHDQDzsfjkkt6IFU3QDFOT1OGGd/view?usp=drive_link"),
-        ("coffee_preparation_d1", 800, "https://drive.google.com/file/d/1trJlVyq9xTRARHBOMi8TOcxLDi804AN3/view?usp=drive_link"),
-        ("nut_assembly_d0", 500, "https://drive.google.com/file/d/1N3Q2NJwn-Wt4OBS8Q04mit92uqrOxqBV/view?usp=drive_link"),
-        ("mug_cleanup_d0", 500, "https://drive.google.com/file/d/1VV2PkvlTT0fGmc6MwwJR8bAtop0hpjIJ/view?usp=drive_link"),
-        ("mug_cleanup_d1", 500, "https://drive.google.com/file/d/1bxJyN2c2yZsgn2FOGWFJsxlgHXWD3eiI/view?usp=drive_link"),
-        ("pick_place_d0", 1000, "https://drive.google.com/file/d/1usOS0sbtmD0wB0L8KhxSjxo6uUmKNT60/view?usp=drive_link"),
-        ("square_d0", 400, "https://drive.google.com/file/d/1FFMWZPzliM4QoiBxbuU69DGfZ4rmt9LL/view?usp=drive_link"),
-        ("square_d1", 400, "https://drive.google.com/file/d/1LJfdITKFQTfPmETVVUjj9YTwiFcmDleZ/view?usp=drive_link"),
-        ("square_d2", 400, "https://drive.google.com/file/d/1X8KCL1eSLT0aieIbFFWOMDb3H2z_czv5/view?usp=drive_link"),
-        ("stack_d0", 400, "https://drive.google.com/file/d/1ZhPBfglfashd8yVwtb4HpDjcxHj_8oAX/view?usp=drive_link"),
-        ("stack_d1", 400, "https://drive.google.com/file/d/1yw9XvvRm4WIsxsFVSR0MOuhM_VgvVdPw/view?usp=drive_link"),
-        ("stack_three_d0", 400, "https://drive.google.com/file/d/1AzuUPtC8K5ZKiuvKAJ3UJ-by1UJqWeLX/view?usp=drive_link"),
-        ("stack_three_d1", 400, "https://drive.google.com/file/d/1PawNzhGCroHdU-4Rl3ZoC7N-6Fj_fErS/view?usp=drive_link"),
-        ("threading_d0", 400, "https://drive.google.com/file/d/1JYIIwRE31ulUYDV0BqrvnzBWzLiVqcKb/view?usp=drive_link"),
-        ("threading_d1", 400, "https://drive.google.com/file/d/1t2Aduv9yic23RlKXg2vryV9jCLwaoFqu/view?usp=drive_link"),
-        ("threading_d2", 400, "https://drive.google.com/file/d/1FUKnUN746m9C7-ReA-o2s58Y8eRyL0oY/view?usp=drive_link"),
-        ("three_piece_assembly_d0", 500, "https://drive.google.com/file/d/1xyTJcrNagEk57Wdoq1YMxnja7ljZC9JW/view?usp=drive_link"),
-        ("three_piece_assembly_d1", 500, "https://drive.google.com/file/d/1HLz9RstJvwkzxUphK2SC9_k_ijv6qFMj/view?usp=drive_link"),
-        ("three_piece_assembly_d2", 500, "https://drive.google.com/file/d/1v59INEmTaMdyiivD3n37J-Oe81xBtQrQ/view?usp=drive_link"),
+        ("hammer_cleanup_d0", 500, "core/hammer_cleanup_d0.hdf5"),
+        ("hammer_cleanup_d1", 500, "core/hammer_cleanup_d1.hdf5"),
+        ("kitchen_d0", 800, "core/kitchen_d0.hdf5"),
+        ("kitchen_d1", 800, "core/kitchen_d1.hdf5"),
+        ("coffee_d0", 400, "core/coffee_d0.hdf5"),
+        ("coffee_d1", 400, "core/coffee_d1.hdf5"),
+        ("coffee_d2", 400, "core/coffee_d2.hdf5"),
+        ("coffee_preparation_d0", 800, "core/coffee_preparation_d0.hdf5"),
+        ("coffee_preparation_d1", 800, "core/coffee_preparation_d1.hdf5"),
+        ("nut_assembly_d0", 500, "core/nut_assembly_d0.hdf5"),
+        ("mug_cleanup_d0", 500, "core/mug_cleanup_d0.hdf5"),
+        ("mug_cleanup_d1", 500, "core/mug_cleanup_d1.hdf5"),
+        ("pick_place_d0", 1000, "core/pick_place_d0.hdf5"),
+        ("square_d0", 400, "core/square_d0.hdf5"),
+        ("square_d1", 400, "core/square_d1.hdf5"),
+        ("square_d2", 400, "core/square_d2.hdf5"),
+        ("stack_d0", 400, "core/stack_d0.hdf5"),
+        ("stack_d1", 400, "core/stack_d1.hdf5"),
+        ("stack_three_d0", 400, "core/stack_three_d0.hdf5"),
+        ("stack_three_d1", 400, "core/stack_three_d1.hdf5"),
+        ("threading_d0", 400, "core/threading_d0.hdf5"),
+        ("threading_d1", 400, "core/threading_d1.hdf5"),
+        ("threading_d2", 400, "core/threading_d2.hdf5"),
+        ("three_piece_assembly_d0", 500, "core/three_piece_assembly_d0.hdf5"),
+        ("three_piece_assembly_d1", 500, "core/three_piece_assembly_d1.hdf5"),
+        ("three_piece_assembly_d2", 500, "core/three_piece_assembly_d2.hdf5"),
     ]
     for task, horizon, link in dataset_infos:
         register_dataset_link(
@@ -134,8 +137,8 @@ def register_all_links():
     ### object transfer datasets ###
     dataset_type = "object"
     dataset_infos = [
-        ("mug_cleanup_o1", 500, "https://drive.google.com/file/d/14llT-UQNjQrDQRdvlq9luvmDzfgdMKOi/view?usp=drive_link"),
-        ("mug_cleanup_o2", 500, "https://drive.google.com/file/d/10M-XTciDT7qQfZTfhL_WEwicH7QIg8QJ/view?usp=drive_link"),
+        ("mug_cleanup_o1", 500, "object/mug_cleanup_o1.hdf5"),
+        ("mug_cleanup_o2", 500, "object/mug_cleanup_o2.hdf5"),
     ]
     for task, horizon, link in dataset_infos:
         register_dataset_link(
@@ -148,22 +151,22 @@ def register_all_links():
     ### robot transfer datasets ###
     dataset_type = "robot"
     dataset_infos = [
-        ("square_d0_panda", 400, "https://drive.google.com/file/d/1-Ez7dG2cUgiLveKWdZnLyq8k_FWZMsG_/view?usp=drive_link"),
-        ("square_d0_sawyer", 400, "https://drive.google.com/file/d/1U3J39kc9k49T1RxcWCk_ua_dOAgqO_Rz/view?usp=drive_link"),
-        ("square_d0_iiwa", 400, "https://drive.google.com/file/d/1bk5m9-hUQAHGkeJWzml-k7O30A7VF0Ab/view?usp=drive_link"),
-        ("square_d0_ur5e", 400, "https://drive.google.com/file/d/14NFNlAN4aCwjieDDMbmKFbDxCxp4Frvf/view?usp=drive_link"),
-        ("square_d1_panda", 400, "https://drive.google.com/file/d/1yXk6G0RqTrdSy6AppGcOfBKlh4DbbRgg/view?usp=drive_link"),
-        ("square_d1_sawyer", 400, "https://drive.google.com/file/d/1V-F6PK4Tqy0aQ0iHwEfVop-9vLOAaySc/view?usp=drive_link"),
-        ("square_d1_iiwa", 400, "https://drive.google.com/file/d/1oRFRev_PpIyNItV187h6gvabEQFIpXgP/view?usp=drive_link"),
-        ("square_d1_ur5e", 400, "https://drive.google.com/file/d/1DSLG_2S6fgJRr2JZ_EBU0CdoRQ0sYuK7/view?usp=drive_link"),
-        ("threading_d0_panda", 400, "https://drive.google.com/file/d/17MM_OPgtht2KbnZjG_J-K37wPD3XAEOd/view?usp=drive_link"),
-        ("threading_d0_sawyer", 400, "https://drive.google.com/file/d/1v3fw7EjXe6_DP62rs2Q2zpMfOP6mHIp2/view?usp=drive_link"),
-        ("threading_d0_iiwa", 400, "https://drive.google.com/file/d/13mqHSSYvTx4KiUCytkOHocPDj5xFw2sP/view?usp=drive_link"),
-        ("threading_d0_ur5e", 400, "https://drive.google.com/file/d/13tNcKtel5nuC5_lA7u8B6K4tC6oGfMwq/view?usp=drive_link"),
-        ("threading_d1_panda", 400, "https://drive.google.com/file/d/1g21kbOnFNOfC4F8PZYpk0vngYoPM4duQ/view?usp=drive_link"),
-        ("threading_d1_sawyer", 400, "https://drive.google.com/file/d/1HttzNikV5uVn5KfzEXVR0nu4xEkH51Xv/view?usp=drive_link"),
-        ("threading_d1_iiwa", 400, "https://drive.google.com/file/d/1MUZh8XqARR7Ei0RR5FoQdq1cq7L6kxmR/view?usp=drive_link"),
-        ("threading_d1_ur5e", 400, "https://drive.google.com/file/d/1SecpwDmaIwFFe01I5FVLS2kPvhzSrFeE/view?usp=drive_link"),
+        ("square_d0_panda", 400, "robot/square_d0_panda.hdf5"),
+        ("square_d0_sawyer", 400, "robot/square_d0_sawyer.hdf5"),
+        ("square_d0_iiwa", 400, "robot/square_d0_iiwa.hdf5"),
+        ("square_d0_ur5e", 400, "robot/square_d0_ur5e.hdf5"),
+        ("square_d1_panda", 400, "robot/square_d1_panda.hdf5"),
+        ("square_d1_sawyer", 400, "robot/square_d1_sawyer.hdf5"),
+        ("square_d1_iiwa", 400, "robot/square_d1_iiwa.hdf5"),
+        ("square_d1_ur5e", 400, "robot/square_d1_ur5e.hdf5"),
+        ("threading_d0_panda", 400, "robot/threading_d0_panda.hdf5"),
+        ("threading_d0_sawyer", 400, "robot/threading_d0_sawyer.hdf5"),
+        ("threading_d0_iiwa", 400, "robot/threading_d0_iiwa.hdf5"),
+        ("threading_d0_ur5e", 400, "robot/threading_d0_ur5e.hdf5"),
+        ("threading_d1_panda", 400, "robot/threading_d1_panda.hdf5"),
+        ("threading_d1_sawyer", 400, "robot/threading_d1_sawyer.hdf5"),
+        ("threading_d1_iiwa", 400, "robot/threading_d1_iiwa.hdf5"),
+        ("threading_d1_ur5e", 400, "robot/threading_d1_ur5e.hdf5"),
     ]
     for task, horizon, link in dataset_infos:
         register_dataset_link(
@@ -176,12 +179,12 @@ def register_all_links():
     ### large_interpolation datasets (larger eval horizons due to longer interpolation segments) ###
     dataset_type = "large_interpolation"
     dataset_infos = [
-        ("coffee_d1", 550, "https://drive.google.com/file/d/1nslJUf5bV1wMNSZWsdeMWg3b9iBv9g5F/view?usp=drive_link"),
-        ("pick_place_d0", 1400, "https://drive.google.com/file/d/1LylKLOzZfv9L47qZl5nOgvTjA2HQysqI/view?usp=drive_link"),
-        ("square_d1", 500, "https://drive.google.com/file/d/1BUynvXIJxFhMXu4zup-Yo6vw8Ki93u5J/view?usp=drive_link"),
-        ("stack_d1", 500, "https://drive.google.com/file/d/18OXuDBbbRN0_hPHbskN2R0ZnRMpM22IW/view?usp=drive_link"),
-        ("threading_d1", 500, "https://drive.google.com/file/d/1TOEfBiHNxNIGmyBRcimq2_g-VGMdfrHy/view?usp=drive_link"),
-        ("three_piece_assembly_d1", 700, "https://drive.google.com/file/d/1MoUBC05iXQD5_y65oFwq3gCvke6JcE5-/view?usp=drive_link"),
+        ("coffee_d1", 550, "large_interpolation/coffee_d1.hdf5"),
+        ("pick_place_d0", 1400, "large_interpolation/pick_place_d0.hdf5"),
+        ("square_d1", 500, "large_interpolation/square_d1.hdf5"),
+        ("stack_d1", 500, "large_interpolation/stack_d1.hdf5"),
+        ("threading_d1", 500, "large_interpolation/threading_d1.hdf5"),
+        ("three_piece_assembly_d1", 700, "large_interpolation/three_piece_assembly_d1.hdf5"),
     ]
     for task, horizon, link in dataset_infos:
         register_dataset_link(

--- a/mimicgen/scripts/download_datasets.py
+++ b/mimicgen/scripts/download_datasets.py
@@ -10,7 +10,7 @@ import argparse
 
 import mimicgen
 import mimicgen.utils.file_utils as FileUtils
-from mimicgen import DATASET_REGISTRY
+from mimicgen import DATASET_REGISTRY, HF_REPO_ID
 
 
 if __name__ == "__main__":
@@ -80,8 +80,9 @@ if __name__ == "__main__":
             # Make sure path exists and create if it doesn't
             os.makedirs(download_dir, exist_ok=True)
             print("")
-            FileUtils.download_url_from_gdrive(
-                url=url, 
+            FileUtils.download_file_from_hf(
+                repo_id=HF_REPO_ID,
+                filename=url,
                 download_dir=download_dir,
                 check_overwrite=True,
             )

--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setup(
         "imageio-ffmpeg",
         "gdown",
         "chardet",
+        "huggingface_hub",
     ],
     eager_resources=['*'],
     include_package_data=True,


### PR DESCRIPTION
- We cannot host the datasets on Google Drive anymore, so we changed the dataset download scripts to pull from Hugging Face instead.