### PR TITLE
Added changes to support env_meta update from mg_config

### DIFF
--- a/mimicgen/configs/config.py
+++ b/mimicgen/configs/config.py
@@ -119,11 +119,10 @@ class MG_Config(Config):
         self.experiment.generation.interpolate_from_last_target_pose = True
 
         # settings related to task used for data generation
-        self.experiment.task.name = None                    # if provided, override the env name in env meta to collect data on a different environment from the one in source data
-        self.experiment.task.robot = None                   # if provided, override the robot name in env meta to collect data on a different robot from the one in source data
-        self.experiment.task.gripper = None                 # if provided, override the gripper in env meta to collect data on a different robot gripper from the one in source data
-        self.experiment.task.interface = None               # if provided, override the environment interface class to use for this task to use a different one from the one in source data
-        self.experiment.task.interface_type = None          # if provided, specify environment interface type (usually one per simulator) to use a different one from the one in source data
+        self.experiment.task.args = Config()                  # if provided, override the arguments passed to the environment constructor, possibly to collect data on a different environment from the one in source data
+        self.experiment.task.args.do_not_lock_keys()
+        self.experiment.task.interface.name = None            # if provided, override the environment interface class to use for this task to use a different one from the one in source data
+        self.experiment.task.interface.type = None            # if provided, specify environment interface type (usually one per simulator) to use a different one from the one in source data
 
         # general settings
         self.experiment.max_num_failures = 50           # maximum number of failure demos to save

--- a/mimicgen/configs/config.py
+++ b/mimicgen/configs/config.py
@@ -119,10 +119,13 @@ class MG_Config(Config):
         self.experiment.generation.interpolate_from_last_target_pose = True
 
         # settings related to task used for data generation
-        self.experiment.task.args = Config()                  # if provided, override the arguments passed to the environment constructor, possibly to collect data on a different environment from the one in source data
-        self.experiment.task.args.do_not_lock_keys()
-        self.experiment.task.interface.name = None            # if provided, override the environment interface class to use for this task to use a different one from the one in source data
-        self.experiment.task.interface.type = None            # if provided, specify environment interface type (usually one per simulator) to use a different one from the one in source data
+        self.experiment.task.name = None                                    # if provided, override the env name in env meta to collect data on a different environment from the one in source data
+        self.experiment.task.robot = None                                   # if provided, override the robot name in env meta to collect data on a different robot from the one in source data
+        self.experiment.task.gripper = None                                 # if provided, override the gripper in env meta to collect data on a different robot gripper from the one in source data
+        self.experiment.task.env_meta_update_kwargs = Config()              # if provided, override the arguments passed to the environment constructor, possibly to collect data on a different environment from the one in source data
+        self.experiment.task.env_meta_update_kwargs.do_not_lock_keys()
+        self.experiment.task.interface = None                               # if provided, override the environment interface class to use for this task to use a different one from the one in source data
+        self.experiment.task.interface_type = None                          # if provided, specify environment interface type (usually one per simulator) to use a different one from the one in source data
 
         # general settings
         self.experiment.max_num_failures = 50           # maximum number of failure demos to save

--- a/mimicgen/exps/templates/robosuite/coffee.json
+++ b/mimicgen/exps/templates/robosuite/coffee.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/coffee_preparation.json
+++ b/mimicgen/exps/templates/robosuite/coffee_preparation.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/hammer_cleanup.json
+++ b/mimicgen/exps/templates/robosuite/hammer_cleanup.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/kitchen.json
+++ b/mimicgen/exps/templates/robosuite/kitchen.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/mug_cleanup.json
+++ b/mimicgen/exps/templates/robosuite/mug_cleanup.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/nut_assembly.json
+++ b/mimicgen/exps/templates/robosuite/nut_assembly.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/pick_place.json
+++ b/mimicgen/exps/templates/robosuite/pick_place.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/square.json
+++ b/mimicgen/exps/templates/robosuite/square.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/stack.json
+++ b/mimicgen/exps/templates/robosuite/stack.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/stack_three.json
+++ b/mimicgen/exps/templates/robosuite/stack_three.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/threading.json
+++ b/mimicgen/exps/templates/robosuite/threading.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/exps/templates/robosuite/three_piece_assembly.json
+++ b/mimicgen/exps/templates/robosuite/three_piece_assembly.json
@@ -22,6 +22,7 @@
             "name": null,
             "robot": null,
             "gripper": null,
+            "env_meta_update_kwargs": {},
             "interface": null,
             "interface_type": null
         },

--- a/mimicgen/scripts/generate_dataset.py
+++ b/mimicgen/scripts/generate_dataset.py
@@ -253,10 +253,9 @@ def generate_dataset(
     )
     # possibly override from config
     if mg_config.experiment.task.interface is not None:
-        if mg_config.experiment.task.interface.name is not None:
-            env_interface_name = mg_config.experiment.task.interface.name
-        if mg_config.experiment.task.interface.type is not None:
-            env_interface_type = mg_config.experiment.task.interface.type
+        env_interface_name = mg_config.experiment.task.interface
+    if mg_config.experiment.task.interface_type is not None:
+        env_interface_type = mg_config.experiment.task.interface_type
 
     # create environment interface to use during data generation
     env_interface = make_interface(

--- a/mimicgen/scripts/generate_dataset.py
+++ b/mimicgen/scripts/generate_dataset.py
@@ -230,9 +230,7 @@ def generate_dataset(
     env = RobomimicUtils.create_env(
         env_meta=env_meta,
         env_class=None,
-        env_name=mg_config.experiment.task.name,
-        robot=mg_config.experiment.task.robot,
-        gripper=mg_config.experiment.task.gripper,
+        env_meta_update_kwargs=mg_config.experiment.task.args,
         camera_names=camera_names,
         camera_height=mg_config.obs.camera_height,
         camera_width=mg_config.obs.camera_width,
@@ -252,9 +250,10 @@ def generate_dataset(
     )
     # possibly override from config
     if mg_config.experiment.task.interface is not None:
-        env_interface_name = mg_config.experiment.task.interface
-    if mg_config.experiment.task.interface_type is not None:
-        env_interface_type = mg_config.experiment.task.interface_type
+        if mg_config.experiment.task.interface.name is not None:
+            env_interface_name = mg_config.experiment.task.interface.name
+        if mg_config.experiment.task.interface.type is not None:
+            env_interface_type = mg_config.experiment.task.interface.type
 
     # create environment interface to use during data generation
     env_interface = make_interface(

--- a/mimicgen/scripts/generate_dataset.py
+++ b/mimicgen/scripts/generate_dataset.py
@@ -230,7 +230,10 @@ def generate_dataset(
     env = RobomimicUtils.create_env(
         env_meta=env_meta,
         env_class=None,
-        env_meta_update_kwargs=mg_config.experiment.task.args,
+        env_name=mg_config.experiment.task.name,
+        robot=mg_config.experiment.task.robot,
+        gripper=mg_config.experiment.task.gripper,
+        env_meta_update_kwargs=mg_config.experiment.task.env_meta_update_kwargs,
         camera_names=camera_names,
         camera_height=mg_config.obs.camera_height,
         camera_width=mg_config.obs.camera_width,

--- a/mimicgen/utils/misc_utils.py
+++ b/mimicgen/utils/misc_utils.py
@@ -26,6 +26,7 @@ def add_red_border_to_frame(frame, ratio=0.02):
     frame[:, -border_size_y:, :] = [255., 0., 0.]
     return frame
 
+
 def deep_update(d, u):
     """
     Recursively update a mapping.

--- a/mimicgen/utils/misc_utils.py
+++ b/mimicgen/utils/misc_utils.py
@@ -26,6 +26,18 @@ def add_red_border_to_frame(frame, ratio=0.02):
     frame[:, -border_size_y:, :] = [255., 0., 0.]
     return frame
 
+def deep_update(d, u):
+    """
+    Recursively update a mapping.
+    """
+    import collections
+    for k, v in u.items():
+        if isinstance(v, collections.abc.Mapping):
+            d[k] = deep_update(d.get(k, {}), v)
+        else:
+            d[k] = v
+    return d
+
 
 class Grid(object):
     """

--- a/mimicgen/utils/robomimic_utils.py
+++ b/mimicgen/utils/robomimic_utils.py
@@ -16,6 +16,8 @@ from robomimic.utils.log_utils import PrintLogger
 import robomimic.utils.env_utils as EnvUtils
 from robomimic.scripts.playback_dataset import playback_dataset, DEFAULT_CAMERAS
 
+from .misc_utils import deep_update
+
 
 def make_print_logger(txt_file):
     """
@@ -32,10 +34,8 @@ def make_print_logger(txt_file):
 
 def create_env(
     env_meta,
-    env_name=None,
+    env_meta_update_kwargs=None,
     env_class=None,
-    robot=None,
-    gripper=None,
     camera_names=None,
     camera_height=84,
     camera_width=84,
@@ -50,14 +50,10 @@ def create_env(
     Args:
         env_meta (dict): environment metadata compatible with robomimic, see
             https://robomimic.github.io/docs/modules/environments.html
-        env_name (str or None): if provided, override environment name 
-            in @env_meta
+        env_meta_update_kwargs (dict or None): if provided, update the environment
+            metadata with these kwargs
         env_class (class or None): if provided, use this class instead of the
             one inferred from @env_meta
-        robot (str or None): if provided, override the robot argument in
-            @env_meta. Currently only supported by robosuite environments.
-        gripper (str or None): if provided, override the gripper argument in
-            @env_meta. Currently only supported by robosuite environments.
         camera_names (list of str or None): list of camera names that correspond to image observations
         camera_height (int): camera height for all cameras
         camera_width (int): camera width for all cameras
@@ -68,19 +64,9 @@ def create_env(
     """
     env_meta = deepcopy(env_meta)
 
-    # maybe override some settings in environment metadata
-    if env_name is not None:
-        env_meta["env_name"] = env_name
-    if robot is not None:
-        # for now, only support this argument for robosuite environments
-        assert EnvUtils.is_robosuite_env(env_meta)
-        assert robot in ["IIWA", "Sawyer", "UR5e", "Panda", "Jaco", "Kinova3"]
-        env_meta["env_kwargs"]["robots"] = [robot]
-    if gripper is not None:
-        # for now, only support this argument for robosuite environments
-        assert EnvUtils.is_robosuite_env(env_meta)
-        assert gripper in ["PandaGripper", "RethinkGripper", "Robotiq85Gripper", "Robotiq140Gripper"]
-        env_meta["env_kwargs"]["gripper_types"] = [gripper]
+    # maybe update environment metadata with additional kwargs
+    if env_meta_update_kwargs is not None:
+        deep_update(env_meta, env_meta_update_kwargs)
 
     if camera_names is None:
         camera_names = []

--- a/mimicgen/utils/robomimic_utils.py
+++ b/mimicgen/utils/robomimic_utils.py
@@ -34,8 +34,8 @@ def make_print_logger(txt_file):
 
 def create_env(
     env_meta,
-    env_class=None,
     env_name=None,
+    env_class=None,
     robot=None,
     gripper=None,
     env_meta_update_kwargs=None,
@@ -53,10 +53,10 @@ def create_env(
     Args:
         env_meta (dict): environment metadata compatible with robomimic, see
             https://robomimic.github.io/docs/modules/environments.html
-        env_class (class or None): if provided, use this class instead of the
-            one inferred from @env_meta
         env_name (str or None): if provided, override environment name 
             in @env_meta
+        env_class (class or None): if provided, use this class instead of the
+            one inferred from @env_meta
         robot (str or None): if provided, override the robot argument in
             @env_meta. Currently only supported by robosuite environments.
         gripper (str or None): if provided, override the gripper argument in

--- a/mimicgen/utils/robomimic_utils.py
+++ b/mimicgen/utils/robomimic_utils.py
@@ -16,7 +16,7 @@ from robomimic.utils.log_utils import PrintLogger
 import robomimic.utils.env_utils as EnvUtils
 from robomimic.scripts.playback_dataset import playback_dataset, DEFAULT_CAMERAS
 
-from .misc_utils import deep_update
+from mimicgen.utils.misc_utils import deep_update
 
 
 def make_print_logger(txt_file):
@@ -34,8 +34,11 @@ def make_print_logger(txt_file):
 
 def create_env(
     env_meta,
-    env_meta_update_kwargs=None,
     env_class=None,
+    env_name=None,
+    robot=None,
+    gripper=None,
+    env_meta_update_kwargs=None,
     camera_names=None,
     camera_height=84,
     camera_width=84,
@@ -50,10 +53,16 @@ def create_env(
     Args:
         env_meta (dict): environment metadata compatible with robomimic, see
             https://robomimic.github.io/docs/modules/environments.html
-        env_meta_update_kwargs (dict or None): if provided, update the environment
-            metadata with these kwargs
         env_class (class or None): if provided, use this class instead of the
             one inferred from @env_meta
+        env_name (str or None): if provided, override environment name 
+            in @env_meta
+        robot (str or None): if provided, override the robot argument in
+            @env_meta. Currently only supported by robosuite environments.
+        gripper (str or None): if provided, override the gripper argument in
+            @env_meta. Currently only supported by robosuite environments.
+        env_meta_update_kwargs (dict or None): if provided, update the environment
+            metadata with these kwargs
         camera_names (list of str or None): list of camera names that correspond to image observations
         camera_height (int): camera height for all cameras
         camera_width (int): camera width for all cameras
@@ -63,6 +72,20 @@ def create_env(
         use_depth_obs (bool or None): optionally override rendering behavior
     """
     env_meta = deepcopy(env_meta)
+
+    # maybe override some settings in environment metadata
+    if env_name is not None:
+        env_meta["env_name"] = env_name
+    if robot is not None:
+        # for now, only support this argument for robosuite environments
+        assert EnvUtils.is_robosuite_env(env_meta)
+        assert robot in ["IIWA", "Sawyer", "UR5e", "Panda", "Jaco", "Kinova3"]
+        env_meta["env_kwargs"]["robots"] = [robot]
+    if gripper is not None:
+        # for now, only support this argument for robosuite environments
+        assert EnvUtils.is_robosuite_env(env_meta)
+        assert gripper in ["PandaGripper", "RethinkGripper", "Robotiq85Gripper", "Robotiq140Gripper"]
+        env_meta["env_kwargs"]["gripper_types"] = [gripper]
 
     # maybe update environment metadata with additional kwargs
     if env_meta_update_kwargs is not None:


### PR DESCRIPTION
This PR contains changes to support a more general `env_meta` update, than was currently supported (only env_name, robot, gripper).

Changes made:
- `config.py`: replaced task keys in MG_Config with more general ones, i.e. args and interface
- `misc_utils.py`: helper deep_update function
- `robomimic_utils.py`: replaced specific key checking in `create_env()` to a more general deep_update
- `generate_dataset.py`: support to use the new config template
