### PR TITLE
add absolute action to generated trajectories

### DIFF
--- a/mimicgen/datagen/data_generator.py
+++ b/mimicgen/datagen/data_generator.py
@@ -254,6 +254,7 @@ class DataGenerator(object):
         generated_obs = []
         generated_datagen_infos = []
         generated_actions = []
+        generated_actions_abs = []
         generated_success = False
         generated_src_demo_inds = [] # store selected src demo ind for each subtask in each trajectory
         generated_src_demo_labels = [] # like @generated_src_demo_inds, but padded to align with size of @generated_actions
@@ -381,6 +382,7 @@ class DataGenerator(object):
                 generated_obs += exec_results["observations"]
                 generated_datagen_infos += exec_results["datagen_infos"]
                 generated_actions.append(exec_results["actions"])
+                generated_actions_abs.append(exec_results["actions_abs"])
                 generated_success = generated_success or exec_results["success"]
                 generated_src_demo_inds.append(selected_src_demo_ind)
                 generated_src_demo_labels.append(selected_src_demo_ind * np.ones((exec_results["actions"].shape[0], 1), dtype=int))
@@ -394,6 +396,7 @@ class DataGenerator(object):
         # merge numpy arrays
         if len(generated_actions) > 0:
             generated_actions = np.concatenate(generated_actions, axis=0)
+            generated_actions_abs = np.concatenate(generated_actions_abs, axis=0)
             generated_src_demo_labels = np.concatenate(generated_src_demo_labels, axis=0)
 
         results = dict(
@@ -402,6 +405,7 @@ class DataGenerator(object):
             observations=generated_obs,
             datagen_infos=generated_datagen_infos,
             actions=generated_actions,
+            actions_abs=generated_actions_abs,
             success=generated_success,
             src_demo_inds=generated_src_demo_inds,
             src_demo_labels=generated_src_demo_labels,

--- a/mimicgen/scripts/generate_dataset.py
+++ b/mimicgen/scripts/generate_dataset.py
@@ -347,6 +347,7 @@ def generate_dataset(
                 observations=(generated_traj["observations"] if mg_config.obs.collect_obs else None),
                 datagen_info=generated_traj["datagen_infos"],
                 actions=generated_traj["actions"],
+                actions_abs=generated_traj["actions_abs"],
                 src_demo_inds=generated_traj["src_demo_inds"],
                 src_demo_labels=generated_traj["src_demo_labels"],
             )
@@ -367,6 +368,7 @@ def generate_dataset(
                     observations=(generated_traj["observations"] if mg_config.obs.collect_obs else None),
                     datagen_info=generated_traj["datagen_infos"],
                     actions=generated_traj["actions"],
+                    actions_abs=generated_traj["actions_abs"],
                     src_demo_inds=generated_traj["src_demo_inds"],
                     src_demo_labels=generated_traj["src_demo_labels"],
                 )

--- a/mimicgen/utils/file_utils.py
+++ b/mimicgen/utils/file_utils.py
@@ -229,6 +229,7 @@ def write_demo_to_hdf5(
     observations,
     datagen_info,
     actions,
+    actions_abs=None,
     src_demo_inds=None,
     src_demo_labels=None,
 ):
@@ -244,6 +245,7 @@ def write_demo_to_hdf5(
         observations (list): list of observation dictionaries
         datagen_info (list): list of DatagenInfo instances
         actions (np.array): actions per timestep
+        actions_abs (np.array or None): absolute actions per timestep
         src_demo_inds (list or None): if provided, list of selected source demonstration indices for each subtask
         src_demo_labels (np.array or None): same as @src_demo_inds, but repeated to have a label for each timestep of the trajectory
     """
@@ -262,6 +264,10 @@ def write_demo_to_hdf5(
 
     # write actions
     ep_data_grp.create_dataset("actions", data=np.array(actions))
+    
+    # write absolute actions if provided
+    if actions_abs is not None:
+        ep_data_grp.create_dataset("actions_abs", data=np.array(actions_abs))
 
     # write simulator states
     if isinstance(states[0], dict):


### PR DESCRIPTION
This PR adds the ability to compute and store absolute actions in generated trajectories. Absolute actions will be stored in a new key called `actions_abs`.