### PR TITLE
Fix Asset problem when building the repo

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+graft mimicgen/models


### PR DESCRIPTION
When installing mimicgen directly via uv (or standard pip without -e), the mimicgen/models/robosuite/assets folder was being excluded from the built wheel. This resulted in the assets missing from the site-packages directory.

This PR adds a MANIFEST.in file to explicitly include the robosuite/assets directory. This ensures the build system properly bundles the assets into the wheel so they are available after installation.